### PR TITLE
Add simple validation DSL

### DIFF
--- a/lib/primalize/single.rb
+++ b/lib/primalize/single.rb
@@ -85,6 +85,10 @@ module Primalize
         Primalizer.new(primalizer, &coerce)
       end
 
+      def validate type, &validation
+        Validation.new(type, validation)
+      end
+
       def type_mismatch_handler= handler
         @type_mismatch_handler = handler
       end
@@ -398,6 +402,29 @@ module Primalize
       def inspect
         params = "(#{@types.map(&:inspect).join(', ')})"
         "any#{@types.empty? ? nil : params}"
+      end
+    end
+
+    class Validation
+      def initialize type, validation
+        @type = type
+        @validation = validation
+      end
+
+      def coerce value
+        if @type.respond_to? :coerce
+          @type.coerce value
+        else
+          value
+        end
+      end
+
+      def === value
+        @type === value && @validation.(coerce(value))
+      end
+
+      def inspect
+        "validate(#{@type.inspect})"
       end
     end
   end

--- a/spec/primalize/single_spec.rb
+++ b/spec/primalize/single_spec.rb
@@ -368,5 +368,18 @@ module Primalize
         CSV
       end
     end
+
+    it 'validates attributes' do
+      my_serializer = Class.new(Single) do
+        attributes(
+          number: validate(integer(&:to_i)) { |value| value.between? 0, 10 },
+        )
+      end
+
+      expect(my_serializer.new(double(number: 10)).call).to eq(number: 10)
+      expect(my_serializer.new(double(number: nil)).call).to eq(number: 0)
+      expect(my_serializer.new(double(number: '0')).call).to eq(number: 0)
+      expect { my_serializer.new(double(number: 12)).call }.to raise_error TypeError
+    end
   end
 end


### PR DESCRIPTION
Following [a conversation](https://dev.to/johncarroll/comment/2a0o) on The Practical Dev, I began thinking that maybe validations on the output aren't a terrible idea. If the contract between an API and a client says that some number will be a float in the range of `0.0...1.0`, checking that it's an instance of `Float` is not good enough to comply with that contract.

This PR (in its current state) is an example of how declaring that could look:

```ruby
class PostPrimalizer < Primalize::Single
  attributes(
    upvote_percentage: validate(float) { |percentage| (0...1).cover? percentage },
  )
end
```

A few things I'm unsure of:
- Naming of `validate`. It _is_ a validation, but so are the type and structure checks. This is intended for the value of primitives, but that's really the only difference.
- The block has a different meaning here than for the other DSL methods. It's a pass/fail depending on truthiness of the return value rather than transforming what it receives. It makes sense with that context, but divergence from the convention feels weird.
- Error messages can't be as nice as for other DSL methods because we can't show _why_ it failed validation, just that it did.

The only thing I can think of to improve on these is to make it work something like this:

```ruby
attributes(
  number: value(integer, between: 0..10),
  email: value(string, match: /\w@\w/),
)
```

That means we have to define a bunch of special-case matchers, but it would let the error messages look good, we wouldn't have to have a different meaning for the block, and it's also another naming suggestion for the DSL method.