### PR TITLE
Support wrapping `optional` around `primalize`

### DIFF
--- a/lib/primalize/single.rb
+++ b/lib/primalize/single.rb
@@ -378,6 +378,24 @@ module Primalize
       def inspect
         "optional(#{@types.map(&:inspect).join(', ')})"
       end
+
+      def coerce value
+        if value.nil?
+          super
+        else
+          type = @types.find { |type| type === value }
+
+          if type.respond_to? :coerce
+            if @coercion
+              @coercion.call(value)
+            else
+              type.coerce(value)
+            end
+          else
+            value
+          end
+        end
+      end
     end
 
     class Any


### PR DESCRIPTION
Prior to this change, nesting `optional(primalize(FooSerializer))` would properly handle `nil` values, but would directly coerce the passed object as JSON rather than calling the specified serializer.

This change updates to call the nested primalize serializer with the object.

----

I'll be honest that I don't deeply understand all the functionality at play here so this solution is largely pattern matching on some of the other implementations, notably the `Array` coercion logic, but thankfully the test suite had solid coverage and helped point me in the correct direction, so functionally I think this is good, but happy to adjust implementation however might make sense.